### PR TITLE
Make WorkoutCard to accept styles

### DIFF
--- a/components/WorkoutCard.js
+++ b/components/WorkoutCard.js
@@ -14,9 +14,6 @@ class WorkoutCard extends Component {
 const styles = StyleSheet.create({
   container: {
     borderRadius: 10,
-    height: 130,
-    marginTop: 20,
-    width: "45%",
     shadowColor: 'black',
     shadowRadius: 6,
     shadowOpacity: 0.2


### PR DESCRIPTION
Fixes #11.
With this change WorkoutCard does not ignore style parameter.
<WorkoutCard style={{..}}> will now work the same way as other native components.

Note that now we can reuse this component one different screen, having **all cards look similar** (Have the same border radius, shadow, etc.), but now with an ability to change other properties, like size, color or other.
