### PR TITLE
Fix buttons layout for Android

### DIFF
--- a/components/WorkoutInfoView.js
+++ b/components/WorkoutInfoView.js
@@ -1,6 +1,6 @@
 //import liraries
 import React, { Component } from 'react';
-import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, Text, TouchableOpacity } from 'react-native';
 import { Button, Icon } from 'react-native-elements';
 import { FontStyles } from '../styles/global';
 import WorkoutCard from '../components/WorkoutCard';
@@ -69,12 +69,13 @@ class WorkoutInfoView extends Component {
                     {workoutName}
                     {exercisesDescription}
                     {exercisesDuration}
-                    <Button
-                        type="clear"
-                        icon={<Icon name="play-arrow" size={22} color={textStyle.color} />}
-                        style={{ flexDirection: 'row', alignSelf: 'flex-end' }}
-                        onPress={this._onPlayButtonClick}
-                    />
+                    <View style={{ alignItems: 'flex-end' }}>
+                        <Button
+                            type="clear"
+                            icon={<Icon name="play-arrow" size={22} color={textStyle.color} />}
+                            onPress={this._onPlayButtonClick}
+                        />
+                    </View>
                 </WorkoutCard>
             </TouchableOpacity>
         );

--- a/screens/Home.js
+++ b/screens/Home.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { ScrollView,View, StyleSheet, Text, Image, TouchableOpacity, TouchableHighlight, SafeAreaView } from 'react-native';
+import { ScrollView, View, StyleSheet, Text, Image, TouchableOpacity, TouchableHighlight, SafeAreaView } from 'react-native';
 import { Button, Icon } from 'react-native-elements';
 import WorkoutView from "../components/WorkoutInfoView";
 import getStyleSheet from "../styles/themestyles";
@@ -166,12 +166,13 @@ class HomeScreen extends React.Component {
                         }
                     </View>
                 </ScrollView>
+                <View style={{ alignItems: 'flex-end' }}>
                 <Button
                     type="clear"
                     icon={<Icon name="add-circle" size={44} color={theme.text.color} />}
-                    style={{ alignSelf: 'flex-end' }}
                     onPress={this._onCreateNewButtonClick}
                 />
+                </View>
             </SafeAreaView>
         );
     }

--- a/screens/SetDetailsView.js
+++ b/screens/SetDetailsView.js
@@ -22,20 +22,29 @@ class SetDetailsView extends React.Component {
 const setViewStyles = StyleSheet.create({
     exersiseSetViewLight: {
         width: "95%",
-        backgroundColor: '#fefefe',
+        backgroundColor: '#fafafa',
         alignSelf: 'center',
         padding: 6,
-        color: '#ffffff',
+        shadowOpacity: null,
+        shadowRadius: null,
+        borderWidth: 0.2,
+        borderColor: '#cccccc',
         marginTop: 10,
-        marginBottom: 10
+        marginBottom: 10,
+        elevation: 0
     },
     exersiseSetViewDark: {
         width: "95%",
-        backgroundColor: '#5f5f5f',
+        backgroundColor: '#8f8f8f',
         alignSelf: 'center',
         padding: 6,
+        shadowOpacity: null,
+        shadowRadius: null,
+        borderWidth: 0.2,
+        borderColor: '#cccccc',
         marginTop: 10,
-        marginBottom: 10
+        marginBottom: 10,
+        elevation: 0
     },
     exersiseSetViewTextLight: {
         color: '#000000'


### PR DESCRIPTION
`alignSelf` does not work the same way on Android as it works on iOS.
Solution is to wrap the element into a `View` and use `alignItems` style property.

This also removes shadow from SetView inside exercise in Details screen.