### PR TITLE
Details for discover

### DIFF
--- a/components/DiscoverItem.js
+++ b/components/DiscoverItem.js
@@ -1,10 +1,13 @@
 import React, { Component } from "react";
 import WorkoutCard from "../components/WorkoutCard";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
-import { Menu, MenuOptions, MenuOption, MenuTrigger } from "react-native-popup-menu";
+import { Menu, MenuOptions, MenuOption, MenuTrigger, renderers } from "react-native-popup-menu";
 import { FontStyles } from '../styles/global';
 
 class DiscoverItem extends Component {
+  onPress = () => { 
+    this.props.onPress(this.props.workout);
+  }
   render() {
     let textStyle;
     if (this.props.style != undefined) {
@@ -34,7 +37,8 @@ class DiscoverItem extends Component {
         <Menu>
           <MenuTrigger
             triggerOnLongPress={true}
-            customStyles={triggerMenuTouchable}
+            customStyles={triggerMenuTouchable} 
+            onAlternativeAction={this.onPress} //because triggerOnLongPress triggers onPress, regular press triggers onAlternativeAction
           >
             <Text style={[textStyle, FontStyles.h1]}>{this.props.workout.name}</Text>
             <View style={styles.info}>
@@ -65,8 +69,8 @@ const styles = StyleSheet.create({
 
 const popUpStyles = {
   optionsContainer: {
-    borderRadius: 12,
-    width: 100
+    borderRadius: 6,
+    width: 130
   }
 };
 

--- a/components/homeRouter.js
+++ b/components/homeRouter.js
@@ -69,11 +69,10 @@ const DiscoverStack = createStackNavigator({
 }, 
 {
   mode: 'modal',
-  headerMode: 'none',
   cardStyle: {
-    backgroundColor:"transparent"
+    opacity: 1.0
   },
-  transparentCard: true
+  transparentCard: false
 })
 const AuthStack = createStackNavigator({ SignIn: LogInOptionsScreen, Register: CreateAccount });
 

--- a/components/homeRouter.js
+++ b/components/homeRouter.js
@@ -26,13 +26,15 @@ const WorkoutStack = createStackNavigator(
     WorkoutDetails: {
       screen: WorkoutDetails,
       navigationOptions: {
-        title: "Details"
+        title: "Details",
+        headerMode: 'none',
+        mode: 'modal',
       }
     },
     RunWorkout: {
       screen: RunWorkoutScreen,
       navigationOptions: {
-        title: "Play workout"
+        title: "Play workout",
       }
     },
     CreateWorkout: {
@@ -51,7 +53,27 @@ const DiscoverStack = createStackNavigator({
     navigationOptions: {
       title: "Discover"
     }
+  },
+  WorkoutDetails: {
+    screen: WorkoutDetails,
+    navigationOptions: {
+      title: "Details"
+    }
+  },
+  RunWorkout: {
+    screen: RunWorkoutScreen,
+    navigationOptions: {
+      title: "Play workout"
+    }
   }
+}, 
+{
+  mode: 'modal',
+  headerMode: 'none',
+  cardStyle: {
+    backgroundColor:"transparent"
+  },
+  transparentCard: true
 })
 const AuthStack = createStackNavigator({ SignIn: LogInOptionsScreen, Register: CreateAccount });
 

--- a/screens/Discover.js
+++ b/screens/Discover.js
@@ -50,12 +50,11 @@ class Discover extends Component {
     if (this.workouts.length > 0) {
       let style = this.state.darkTheme ? styles.workoutViewDark : styles.workoutViewLight;
       discoverWorkoutViews = []
-      for(var index =0; index< this.workouts.length; index++) {
-        const workout = this.workouts[index];
+      this.workouts.map( (workout, index) => { 
         discoverWorkoutViews.push(<DiscoverItem workout={workout} key={index} onPress={(workout) => { this._onWorkoutSelect(workout) }} style={style} />)
-      }
+      })
     } else {
-      discoverWorkoutViews = <Text>Add spinner</Text>
+      discoverWorkoutViews = <Text>Loading...</Text>
     }
     const theme = getStyleSheet(this.state.darkTheme);
     return (

--- a/screens/Discover.js
+++ b/screens/Discover.js
@@ -24,6 +24,7 @@ class Discover extends Component {
         }
       }
     );
+    this._onWorkoutSelect = this._onWorkoutSelect.bind(this);
   }
   componentDidMount() {
     this.fetchWorkoutsFromDatabase()
@@ -41,14 +42,18 @@ class Discover extends Component {
       this.setState({ dataReceived: true })
     });
   }
+  _onWorkoutSelect(workout) {
+    this.props.navigation.navigate('WorkoutDetails', { workout: workout, discoverWorkout: true });
+  }
   render() {
     var discoverWorkoutViews;
     if (this.workouts.length > 0) {
       let style = this.state.darkTheme ? styles.workoutViewDark : styles.workoutViewLight;
       discoverWorkoutViews = []
-      this.workouts.forEach(function (workout, index) {
-        discoverWorkoutViews.push(<DiscoverItem workout={workout} key={index} onPress={(index) => { this.onTimerSelect(index) }} style={style} />)
-      });
+      for(var index =0; index< this.workouts.length; index++) {
+        const workout = this.workouts[index];
+        discoverWorkoutViews.push(<DiscoverItem workout={workout} key={index} onPress={(workout) => { this._onWorkoutSelect(workout) }} style={style} />)
+      }
     } else {
       discoverWorkoutViews = <Text>Add spinner</Text>
     }

--- a/screens/WorkoutDetails.js
+++ b/screens/WorkoutDetails.js
@@ -1,55 +1,110 @@
 import React from 'react';
-import { ScrollView, View, StyleSheet, Text, TextInput, Picker, SafeAreaView } from 'react-native';
+import { Alert, ScrollView, View, StyleSheet, Text, TextInput, Picker, SafeAreaView } from 'react-native';
 import { Button } from 'react-native-elements';
 import getStyleSheet from "../styles/themestyles";
 import { FontStyles, ScreenStyles } from '../styles/global';
 import ExerciseDetailsView from './ExerciseDetailsView';
-
+import { NavigationActions } from 'react-navigation';
 class WorkoutDetailsScreen extends React.Component {
     constructor(props) {
         super(props)
 
         const { params } = this.props.navigation.state;
         this.workout = params.workout 
+        this.discoverWorkout = params.discoverWorkout 
         //TODO: this should show all the categories available in the database
         this.workoutCategories = [
             'Stretching', 'Cardio'
         ]
         this.state = {
             darkTheme: window.darkTheme,
-            editable: true,
+            editing: false,
             workoutcategory: this.workout.category
         }
+        this.closeButtonPressed = this.closeButtonPressed.bind(this);
+        this.editButtonPressed = this.editButtonPressed.bind(this);
     }
 
+    componentDidMount(){ 
+        this.props.navigation.setParams({ closeButtonPressed: this.closeButtonPressed, editButtonPressed: this.editButtonPressed });
+        const backAction = NavigationActions.back({
+            key: 'Profile',
+          });
+        this.props.navigation.dispatch(backAction);
+    }
+
+    static navigationOptions = ({ navigation }) => {
+        const { params = {} } = navigation.state;
+        
+        if(params.discoverWorkout) { 
+            return {
+                headerLeft: <Button type="clear" onPress={params.closeButtonPressed} title="Close" />
+            }
+        }
+        //Show edit if the workout is in user library
+        else {
+            console.warn(navigation.getParam('editing'))
+            let buttonName = navigation.getParam('editing') ? "Save" : "Edit"
+            return {
+            headerLeft: <Button type="clear" onPress={params.closeButtonPressed} title="Close" />,
+            headerRight: <Button type="clear" onPress={params.editButtonPressed} title={buttonName} />,
+            }
+        };
+    };
+
+    closeButtonPressed() {
+        if(this.state.editing) {
+            Alert.alert(
+                "Workout not saved",
+                "All unsaved changes will be lost",
+                [
+                  {
+                    text: "Ok",
+                    onPress: () => this.props.navigation.pop(),
+                  },
+                  {
+                    text: "Cancel",
+                    style: "cancel"
+                  }
+                ],
+                { cancelable: false }
+              );
+        }
+        else {this.props.navigation.pop()}
+    }
+    editButtonPressed() {
+        this.props.navigation.state.params.finishedEditing(this.workout);
+        this.setState({editing: !this.state.editing})
+        this.props.navigation.setParams({editing: !this.state.editing})
+    }
     render() {
         const theme = getStyleSheet(this.state.darkTheme);
         if(this.workout.exercises === undefined ) {
             return null
         }
+        var menu;
+        if(this.discoverWorkout) {
+        } else {
+            
+        }
+        
         return (
-            <SafeAreaView style={[ScreenStyles.screenContainer, theme.background]}>
+            <SafeAreaView style={[ScreenStyles.screenContainer, theme.background, {top: '15%'}]}>
+               {menu}
                 <ScrollView style={ScreenStyles.screenContainer}>
-                <Button
-                    type="clear"
-                    title="save"
-                    style={{ flexDirection: 'row',  alignSelf: 'flex-end'}}
-                    onPress={() => {
-                        //Calback to home view
-                        this.props.navigation.state.params.finishedEditing(this.workout);
-                    }}/>
+                
                     <View style={styles.container}>
                         <View style={styles.workoutInfo}>
                             <TextInput
                                 underlineColorAndroid='transparent'
-                                editable={this.state.editable}
+                                editable={this.state.editing}
                                 onChangeText={(text) => this.workout.name = text}
                                 style={[theme.text, FontStyles.h1, FontStyles.bold]}
                             >{this.workout.name}</TextInput>
                             <View style={{ flexDirection: "row", alignItems: "center", justifyContent: 'flex-start' }}>
                                 <Text style={theme.text}>Category:</Text>
                                 <Picker
-                                    enabled={this.state.editable}
+                                    enabled={this.state.editing}
                                     selectedValue={this.state.workoutcategory}
                                     style={{ height: 30, minWidth: '30%', alignSelf: 'flex-start' }} itemStyle={{ height: 34, ...FontStyles.default, ...theme.text,}}
                                     onValueChange={(itemValue, itemIndex) =>
@@ -84,7 +139,7 @@ class WorkoutDetailsScreen extends React.Component {
 const styles = StyleSheet.create({
     container: {
         width: '90%',
-        left: "5%",
+        left: "5%"
     },
     exercises: {
         marginTop: 10

--- a/screens/WorkoutDetails.js
+++ b/screens/WorkoutDetails.js
@@ -78,24 +78,11 @@ class WorkoutDetailsScreen extends React.Component {
     }
     render() {
         const theme = getStyleSheet(this.state.darkTheme);
-        const screenCardStyle = this.discoverWorkout ? {top: '15%' , borderRadius: 24} : {}
-        var topMenu, bottomPadding;
         if(this.workout.exercises === undefined ) {
             return null
         }
-        if(this.discoverWorkout) {
-            topMenu = <View>
-                <Icon type='MaterialIcons'
-                name="expand-more"
-                size={30}
-                color='#aaaaaa'/>
-            </View>
-            //to push up scroll view so it is not hidden begind the navigation tab
-            bottomPadding= <View style={{height: 130, backgroundColor: 'transparent'}}></View>
-        }
         return (
-            <SafeAreaView style={[ScreenStyles.screenContainer, theme.background, screenCardStyle]}>
-               {topMenu}
+            <SafeAreaView style={[ScreenStyles.screenContainer, theme.background]}>
                 <ScrollView style={[ScreenStyles.screenContainer, {height: 20}]}>
                     <View style={styles.container}>
                         <View style={styles.workoutInfo}>
@@ -133,7 +120,6 @@ class WorkoutDetailsScreen extends React.Component {
                                 })
                             }
                         </View>
-                        {bottomPadding}
                     </View>
                 </ScrollView>
                 

--- a/screens/WorkoutDetails.js
+++ b/screens/WorkoutDetails.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Alert, ScrollView, View, StyleSheet, Text, TextInput, Picker, SafeAreaView } from 'react-native';
-import { Button } from 'react-native-elements';
+import { Button, Icon } from 'react-native-elements';
 import getStyleSheet from "../styles/themestyles";
 import { FontStyles, ScreenStyles } from '../styles/global';
 import ExerciseDetailsView from './ExerciseDetailsView';
@@ -43,11 +43,10 @@ class WorkoutDetailsScreen extends React.Component {
         }
         //Show edit if the workout is in user library
         else {
-            console.warn(navigation.getParam('editing'))
             let buttonName = navigation.getParam('editing') ? "Save" : "Edit"
             return {
-            headerLeft: <Button type="clear" onPress={params.closeButtonPressed} title="Close" />,
-            headerRight: <Button type="clear" onPress={params.editButtonPressed} title={buttonName} />,
+                headerLeft: <Button type="clear" onPress={params.closeButtonPressed} title="Close" />,
+                headerRight: <Button type="clear" onPress={params.editButtonPressed} title={buttonName} />,
             }
         };
     };
@@ -79,20 +78,25 @@ class WorkoutDetailsScreen extends React.Component {
     }
     render() {
         const theme = getStyleSheet(this.state.darkTheme);
+        const screenCardStyle = this.discoverWorkout ? {top: '15%' , borderRadius: 24} : {}
+        var topMenu, bottomPadding;
         if(this.workout.exercises === undefined ) {
             return null
         }
-        var menu;
         if(this.discoverWorkout) {
-        } else {
-            
+            topMenu = <View>
+                <Icon type='MaterialIcons'
+                name="expand-more"
+                size={30}
+                color='#aaaaaa'/>
+            </View>
+            //to push up scroll view so it is not hidden begind the navigation tab
+            bottomPadding= <View style={{height: 130, backgroundColor: 'transparent'}}></View>
         }
-        
         return (
-            <SafeAreaView style={[ScreenStyles.screenContainer, theme.background, {top: '15%'}]}>
-               {menu}
-                <ScrollView style={ScreenStyles.screenContainer}>
-                
+            <SafeAreaView style={[ScreenStyles.screenContainer, theme.background, screenCardStyle]}>
+               {topMenu}
+                <ScrollView style={[ScreenStyles.screenContainer, {height: 20}]}>
                     <View style={styles.container}>
                         <View style={styles.workoutInfo}>
                             <TextInput
@@ -129,8 +133,10 @@ class WorkoutDetailsScreen extends React.Component {
                                 })
                             }
                         </View>
+                        {bottomPadding}
                     </View>
                 </ScrollView>
+                
             </SafeAreaView>
         );
     }


### PR DESCRIPTION
Different options on Details screen when opening workout from Discover and User Library. 

Added Routes for Run and Details to Discover Stack. Now returning from those screens bring the user back to the correct route (instead of always bringing to Home route)

Workout can be edited if selected from home screen.
<img src="https://user-images.githubusercontent.com/8983928/60637214-81ab3c80-9de7-11e9-8fbe-b98dc2e90873.png" width="250">
<br>
Only details and **no edit** if from Discover
<img src="https://user-images.githubusercontent.com/8983928/60637237-9ab3ed80-9de7-11e9-9510-7c10bb5c26d6.png" width="250">
