### PR TITLE
Remove tab bar name on login screen

### DIFF
--- a/components/homeRouter.js
+++ b/components/homeRouter.js
@@ -74,7 +74,7 @@ const DiscoverStack = createStackNavigator({
   },
   transparentCard: false
 })
-const AuthStack = createStackNavigator({ SignIn: LogInOptionsScreen, Register: CreateAccount });
+const AuthStack = createStackNavigator({ SignIn: LogInOptionsScreen, Register: CreateAccount }, {headerMode: 'none'});
 
 const TabNavigator = createBottomTabNavigator(
   {


### PR DESCRIPTION
Small UI adjustment. 
Removed Tab bar name on Login screen
Before:
<img src="https://user-images.githubusercontent.com/8983928/61086422-cabf4a00-a400-11e9-890f-490edaedbcc4.png" width=200/>
<hr/>
After
<img src="https://user-images.githubusercontent.com/8983928/61086421-cabf4a00-a400-11e9-9845-0dad7cb1082b.png" width=200/>
