### PR TITLE
Fix routing of settings screen. Fixed visual transition between tabs

### DIFF
--- a/components/homeRouter.js
+++ b/components/homeRouter.js
@@ -16,7 +16,8 @@ import WorkoutDetails from "../screens/WorkoutDetails";
 import RunWorkoutScreen from "../screens/RunWorkout/RunWorkoutScreen";
 import Discover from "../screens/Discover";
 import CreateWorkoutScreen from "../screens/CreateWorkout";
-
+import getStyleSheet from "../styles/themestyles";
+import Ionicons from 'react-native-vector-icons/Ionicons';
 //More about navigation https://reactnavigation.org/docs/en/auth-flow.html
 //createStackNavigator is a function that takes a route configuration object and an options object and returns a React component.
 const WorkoutStack = createStackNavigator(
@@ -73,7 +74,8 @@ const DiscoverStack = createStackNavigator(
       navigationOptions: {
         title: "Play workout"
       }
-    }
+    },
+    Settings: SettingsScreen,
   },
   {
     mode: "modal",
@@ -92,19 +94,33 @@ const TabNavigator = createBottomTabNavigator({
   WorkoutStack: {
     screen: WorkoutStack,
     navigationOptions: {
-       tabBarIcon: () => <Icon name="home" size={30} />
+       tabBarIcon: ({ tintColor }) => {
+        const iconName = "home"
+        return <Icon name={iconName} size={30} color={tintColor} />;
+       } 
     }
   },
   Discover: {
     screen: DiscoverStack,
     navigationOptions: {
-       tabBarIcon: () => <Icon name="md-compass" type="ionicon" size={30} />
+       tabBarIcon: ({ tintColor }) => {
+        const iconName = "md-compass"
+        return <Icon name={iconName} type="ionicon" size={30} color={tintColor} />;
+       } 
     }
-  }
+  },
 },
 {
   tabBarOptions: {
-    showLabel: false
+    resetOnBlur: true,
+    showLabel: false,
+    lazy: false,
+    activeTintColor: '#000000',
+    inactiveTintColor: '#999999',
+    // activeBackgroundColor: getStyleSheet(window.darkTheme).background.backgroundColor,
+    style: {
+      backgroundColor: getStyleSheet(window.darkTheme).background.backgroundColor
+    },
   }
 });
 

--- a/components/homeRouter.js
+++ b/components/homeRouter.js
@@ -17,7 +17,6 @@ import RunWorkoutScreen from "../screens/RunWorkout/RunWorkoutScreen";
 import Discover from "../screens/Discover";
 import CreateWorkoutScreen from "../screens/CreateWorkout";
 import getStyleSheet from "../styles/themestyles";
-import Ionicons from 'react-native-vector-icons/Ionicons';
 //More about navigation https://reactnavigation.org/docs/en/auth-flow.html
 //createStackNavigator is a function that takes a route configuration object and an options object and returns a React component.
 const WorkoutStack = createStackNavigator(
@@ -112,12 +111,8 @@ const TabNavigator = createBottomTabNavigator({
 },
 {
   tabBarOptions: {
-    resetOnBlur: true,
-    showLabel: false,
-    lazy: false,
     activeTintColor: '#000000',
     inactiveTintColor: '#999999',
-    // activeBackgroundColor: getStyleSheet(window.darkTheme).background.backgroundColor,
     style: {
       backgroundColor: getStyleSheet(window.darkTheme).background.backgroundColor
     },


### PR DESCRIPTION
- Fixed redirecting issue when returning from Settings screen called from Discover screen would result in navigating to Home screen.
- Fixed tab navigation bar icons. Now active and inactive tabs are visually different
 
<img src="https://user-images.githubusercontent.com/8983928/62231515-33f80480-b392-11e9-9862-4aefcd54cb67.png" width=250/>