### PR TITLE
Incorrect id assignment

### DIFF
--- a/components/DatabaseManager.js
+++ b/components/DatabaseManager.js
@@ -46,13 +46,13 @@ export default class DatabaseManager {
         })
     };
     //Save passed workout to the user library
-    static AddWorkoutToUserLibrary(workout) {
+    static AddWorkoutToUserLibrary(w) {
         return new Promise((resolve, reject) => {
             const user = firebase.auth().currentUser;
             if (user) {
                 const userDataRef = firebase.database().ref("users/" + user.uid + "/workouts/");
                 var newWorkoutRef = userDataRef.push();
-                workout.id = newWorkoutRef.key;
+                const workout = {...w, id: newWorkoutRef.key}
                 newWorkoutRef.set(workout).then(data => {
                     resolve();
                 }).catch(error => {

--- a/screens/Discover.js
+++ b/screens/Discover.js
@@ -85,6 +85,7 @@ class Discover extends Component {
             wrks.push(workout)
           });
           this.workouts = wrks
+          console.warn(JSON.stringify(this.workouts.map(w => {return w.id})))
           onCompletion();
         });
       }
@@ -93,12 +94,12 @@ class Discover extends Component {
 
   refreshUserWorkouts(onCompletion) {
     DatabaseManager.GetCurrentUserSavedDiscoverWorkouts().then(references => {
-      this.workouts.forEach(workout => {
-        //check if the discover workout was added to the user library
-        if (references) {
-          workout.added = references.includes(workout.id);
-        }
-      });
+      if (references && references.length > 0) {
+        this.workouts.forEach(workout => {
+          //check if the discover workout was added to the user library
+            workout.added = references.includes(workout.id);
+          });
+      }
       onCompletion();
     });
   }


### PR DESCRIPTION
Fixed an issue when assigning an id for a workout added from the Discover screen to the user library resulted in changing an original workout id. As a result "Added to your library" label would disappear after navigating from Discover screen.