### PR TITLE
Fix empty createdBy field for Facebook users

### DIFF
--- a/screens/CreateWorkout.js
+++ b/screens/CreateWorkout.js
@@ -233,7 +233,7 @@ class CreateWorkoutScreen extends React.Component {
             id: newWorkoutRef.key,
             name: this.state.name,
             category: this.state.category,
-            createdBy: user.email,
+            createdBy: user.email !== null ? user.email : user.providerData[0].email,
             timeCreated: timestamp,
             exercises: this.state.exercises
           })

--- a/screens/Discover.js
+++ b/screens/Discover.js
@@ -85,7 +85,6 @@ class Discover extends Component {
             wrks.push(workout)
           });
           this.workouts = wrks
-          console.warn(JSON.stringify(this.workouts.map(w => {return w.id})))
           onCompletion();
         });
       }


### PR DESCRIPTION
Not sure why the user data returned by rn-firebase is a little bit different from what it used to be.